### PR TITLE
Remove `maxsplit=` to support Bazel v1.0

### DIFF
--- a/R/repositories.bzl
+++ b/R/repositories.bzl
@@ -30,7 +30,7 @@ def _r_repository_impl(rctx):
         fail(("No sources found for repository '@%s'. Perhaps this package is " % rctx.name) +
              "not available for your R version.")
 
-    archive_basename = rctx.attr.urls[0].rsplit("/", maxsplit = 1)[1]
+    archive_basename = rctx.attr.urls[0].rsplit("/", 1)[1]
 
     if rctx.attr.pkg_type == "source":
         rctx.download_and_extract(


### PR DESCRIPTION
Bazel v1.0 changed some parameters to positional-only (https://github.com/bazelbuild/bazel/issues/9998), which broke rules_r due to a use of `maxsplit=` in the repository setup. This PR fixes it.