### PR TITLE
fix mac makevars

### DIFF
--- a/R/internal/makevars/Makevars.darwin.sh
+++ b/R/internal/makevars/Makevars.darwin.sh
@@ -38,17 +38,20 @@ done
 export HOME=/tmp  # Needed for Homebrew.
 # Prefer brew clang if available, for openmp support.
 CC=""
+CXX=""
 CPPFLAGS=""
 LDFLAGS=""
 OPENMP_FLAGS=""
 if $BREW && brew ls --versions llvm > /dev/null 2>/dev/null; then
   LLVM_PREFIX="$(brew --prefix llvm)"
   CC="${LLVM_PREFIX}/bin/clang"
+  CXX="${LLVM_PREFIX}/bin/clang++"
   CPPFLAGS="-I${LLVM_PREFIX}/include"
   LDFLAGS="-L${LLVM_PREFIX}/lib"
   OPENMP_FLAGS="-fopenmp"
 elif command -v clang > /dev/null; then
   CC=$(command -v clang)
+  CXX=$(command -v clang++)
 else
   warn "clang not found"
   exit
@@ -79,6 +82,7 @@ fi
 
 subst=(
 's|@CC@|'"${CC}"'|g;'
+'s|@CXX@|'"${CXX}"'|g;'
 's|@CPPFLAGS@|'"${CPPFLAGS}"'|g;'
 's|@LDFLAGS@|'"${LDFLAGS}"'|g;'
 's|@GFORTRAN@|'"${GFORTRAN}"'|g;'

--- a/R/internal/makevars/Makevars.darwin.tpl
+++ b/R/internal/makevars/Makevars.darwin.tpl
@@ -21,7 +21,7 @@ FC=${F77}
 FLIBS=-L@GCC_LIB_PATH@ -lgfortran -lquadmath -lm
 
 CC = @CC@
-CXX = @CC@
+CXX = @CXX@
 CPPFLAGS = @CPPFLAGS@
 LDFLAGS = @LDFLAGS@
 

--- a/R/scripts/build.sh
+++ b/R/scripts/build.sh
@@ -183,7 +183,7 @@ TMP_FILES+=("${TMP_SRC_PKG}")
 TZ=UTC find "${TMP_SRC_PKG}" -type f -exec touch -t 197001010000 {} \+
 
 # Override flags to the compiler for reproducible builds.
-R_MAKEVARS_SITE="$(mktemp)"
+R_MAKEVARS_SITE=${R_MAKEVARS_SITE:="$(mktemp)"}
 TMP_FILES+=("${R_MAKEVARS_SITE}")
 export R_MAKEVARS_SITE
 
@@ -194,7 +194,8 @@ repro_flags=(
 "-D__TIME__=\"redacted\""
 "-fdebug-prefix-map=\"${EXEC_ROOT}/=\""
 )
-echo "CPPFLAGS += ${repro_flags[*]}" > "${R_MAKEVARS_SITE}"
+touch ${R_MAKEVARS_SITE}
+echo "CPPFLAGS += ${repro_flags[*]}" >> "${R_MAKEVARS_SITE}"
 
 # Check if we just need to build the source archive.
 if "${BUILD_SRC_ARCHIVE:-"false"}"; then


### PR DESCRIPTION
Fix an issue where `Makevars.darwin`, originally produced by template, gets overwritten latter.

Templated
https://github.com/grailbio/rules_r/blob/3b6d3260f20cc04f71ed7246a46982428b743763/R/scripts/build.sh#L134
Overwritten
https://github.com/grailbio/rules_r/blob/3b6d3260f20cc04f71ed7246a46982428b743763/R/scripts/build.sh#L197


Furthermore, fix `CXX` variable to point to actual C++ compiler instead of `CC`. This is inline with recommendations given in R manual: https://cran.r-project.org/doc/manuals/R-admin.html#macOS-packages