### PR TITLE
fix: r_binary should respect --stamp flag

### DIFF
--- a/R/internal/BUILD
+++ b/R/internal/BUILD
@@ -1,0 +1,19 @@
+load("//R/internal:context.bzl", "r_context_data")
+
+package(default_visibility = ["//visibility:public"])
+
+# Detect if the build is running under --stamp
+config_setting(
+    name = "stamp",
+    values = {"stamp": "true"},
+)
+
+# Modelled after go_context_data from rules_go
+# passes config values to starlark via a provider
+r_context_data(
+    name = "r_context_data",
+    stamp = select({
+        "@com_grail_rules_r//R/internal:stamp": True,
+        "//conditions:default": False,
+    }),
+)

--- a/R/internal/context.bzl
+++ b/R/internal/context.bzl
@@ -1,0 +1,19 @@
+"r_context_data rule"
+
+load("@com_grail_rules_r//R:providers.bzl", "RContextInfo")
+
+_DOC = """r_context_data gathers information about the build configuration.
+It is a common dependency of all binary targets."""
+
+def _impl(ctx):
+    return [RContextInfo(stamp = ctx.attr.stamp)]
+
+# Modelled after go_context_data in rules_go
+# Works around github.com/bazelbuild/bazel/issues/1054
+r_context_data = rule(
+    implementation = _impl,
+    attrs = {
+        "stamp": attr.bool(mandatory = True),
+    },
+    doc = _DOC,
+)

--- a/R/providers.bzl
+++ b/R/providers.bzl
@@ -49,3 +49,9 @@ RBinary = provider(
         "pkg_deps": "list of direct package dependencies for this and other binary dependencies",
     },
 )
+
+#Modelled after _GoContextData in rules_go/go/private/context.bzl
+RContextInfo = provider(
+    doc = "Provides data about the build context, like config_setting's",
+    fields = ["stamp"],
+)

--- a/R/scripts/system_state.sh
+++ b/R/scripts/system_state.sh
@@ -31,4 +31,4 @@ printf "\\n=== R environment ===\\n"
 # https://stat.ethz.ch/R-manual/R-devel/library/base/html/EnvVar.html
 # But in build actions, bazel will mask most of the ones not coming from R, so we can ignore those.
 # shellcheck disable=SC2086
-"${RSCRIPT:-"Rscript"}" --no-init-file ${ARGS:-} -e 'Sys.getenv()' | grep "^R_"
+"${RSCRIPT:-"Rscript"}" --no-init-file ${ARGS:-} -e 'Sys.getenv()' | grep "^R_" | grep -v "^R_SESSION_TMPDIR"

--- a/README.md
+++ b/README.md
@@ -608,6 +608,18 @@ the runfiles of the root executable.
         <p>A list of arguments to pass to the src script.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>stamp</code></td>
+      <td>
+        <p><code>Integer; optional; default is -1</code></p>
+        <p>Enable link stamping. Whether to encode build information into the binary. Possible values:</p>
+        <ul>
+          <li>stamp = 1: Stamp the build information into the binary. Stamped binaries are only rebuilt when their dependencies change. Use this if there are tests that depend on the build information.</li>
+          <li>stamp = 0: Always replace build information by constant values. This gives good build result caching.</li>
+          <li>stamp = -1: Embedding of build information is controlled by the --[no]stamp flag.</li>
+        </ul>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/tests/exampleA/BUILD
+++ b/tests/exampleA/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_grail_rules_r//R:defs.bzl", "r_pkg")
+load("@com_grail_rules_r//R:defs.bzl", "r_pkg", "r_test")
 
 r_pkg(
     name = "exampleA",
@@ -23,4 +23,9 @@ r_pkg(
         ],
     ),
     visibility = ["//exampleB:__pkg__"],
+)
+
+r_test(
+    name = "test",
+    src = "//exampleA/R:fn.R",
 )

--- a/tests/exampleA/R/BUILD
+++ b/tests/exampleA/R/BUILD
@@ -1,0 +1,1 @@
+exports_files(["fn.R"])


### PR DESCRIPTION
Currently, `r_test` always include stamp files which change over each build/host. This makes test [incompatible](https://github.com/bazelbuild/bazel/issues/10075) with bazel [remote cache](https://docs.bazel.build/versions/master/remote-caching.html) due to changing inputs.

Apply a similar fix as https://github.com/bazelbuild/rules_nodejs/pull/1441 where we respect `--[no]stamp` flag. Furthermore, adopt similar behavior as [`cc_binary`](https://docs.bazel.build/versions/2.0.0/be/c-cpp.html#cc_binary) where `stamp` can be overridden on a target by target basis. This is mostly for backward compatible reasons in case users have been consuming `{stable,volatile}-status.txt` on these rules.

Added a `r_test` target in example for easier debugging in the future.

**Note** This is a breaking change where stamp files are no longer available for `r_binary/r_markdown/r_test` by default. However, this seems to be the expected behavior for [`--[no]stamp`](https://docs.bazel.build/versions/master/user-manual.html#flag--stamp). I don't expect status files are actually depended on for majority of users.

Lastly, exclude `R_SESSION_TMPDIR` environment variable in `r_toolchain_generic_state` which changes on each toolchain registry for different hosts and sessions. This was also breaking remote caching and sometimes resulted flaky local disk caches as well.