### PR TITLE
cc_library from R package native code

### DIFF
--- a/R/scripts/check.sh.tpl
+++ b/R/scripts/check.sh.tpl
@@ -27,22 +27,28 @@ fi
 # Export path to tool needed for the test.
 {tools_export_cmd}
 
-# Help find any .so deps in bazel's execution root.
-# This is independent of how we install the package in build.sh because this
-# test is done through the source archive which can not contain any .so files
-# in src subdirectory, and so the .so files have to be found outside the
-# package.
+# Hack: We copied these files to the inst/libs directory in build.sh, let's
+# ensure that the compiler can find them at link time. Note that these files
+# still have the patches we made to them (e.g. through install_name_tool) in
+# build.sh.
 C_SO_FILES=({c_so_files})
-SO_DIRS=()
-for so in "${C_SO_FILES[@]:+"${C_SO_FILES[@]}"}"; do
-  SO_DIRS+=("${EXEC_ROOT}/$(dirname "${so}")")
+C_SO_LD_FLAGS=""
+for so_file in "${C_SO_FILES[@]:+"${C_SO_FILES[@]}"}"; do
+  so_file_name="$(basename "${so_file}")"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    C_SO_LD_FLAGS+="../inst/libs/${so_file_name} "
+  elif [[ "$(uname)" == "Linux" ]]; then
+    C_SO_LD_FLAGS+="-L../inst/libs -l:${so_file_name} "
+  fi
 done
-LD_LIBRARY_PATH+=$(IFS=:; echo "${SO_DIRS[*]:+"${SO_DIRS[*]}"}")
-export LD_LIBRARY_PATH
+if [[ "$(uname)" == "Linux" ]]; then
+  #shellcheck disable=SC2016
+  C_SO_LD_FLAGS+="-Wl,-rpath,"\''$$ORIGIN'\'" "
+fi
 
 C_LIBS_FLAGS="{c_libs_flags}"
 C_CPP_FLAGS="{c_cpp_flags}"
-export PKG_LIBS="${C_LIBS_FLAGS//_EXEC_ROOT_/${EXEC_ROOT}/}"
+export PKG_LIBS="${C_SO_LD_FLAGS}${C_LIBS_FLAGS//_EXEC_ROOT_/${EXEC_ROOT}/}"
 export PKG_CPPFLAGS="${C_CPP_FLAGS//_EXEC_ROOT_/${EXEC_ROOT}/}"
 
 if [[ "{r_makevars_site}" ]]; then

--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ r_repository(urls, strip_prefix, type, sha256, build_file)
 
 Repository rule in place of `new_http_archive` that can run razel to generate
 the BUILD file automatically. See section on
-[external packages](#external-packages).
+[external packages](#external-packages) and [Razel scripts][scripts].
 
 <table class="table table-condensed table-bordered table-params">
   <colgroup>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,12 @@ caution.
 ## razel.R
 
 Functions in this script help generate `BUILD` files for your own package and
-for packages from external repositories like CRAN and Bioc.
+for packages from external repositories like CRAN and Bioc. By default, targets
+are created for `r_pkg` and `r_library` rules. If the argument `no_test_rules`
+is `FALSE`, then targets are also made available for `r_unit_test` and
+`r_pkg_test` rules. If the package contains native code, then a `cc_library`
+target is also available that provides a way to depend on just the native code
+in the package.
 
 For your own package, use the function `buildify` directly. For external
 packages, you will have to first create a local repository containing all the

--- a/tests/coverage/coverage_test.sh
+++ b/tests/coverage/coverage_test.sh
@@ -42,6 +42,9 @@ expect_equal() {
   local expected="$1"
   local actual="$2"
 
+  # coverage profiling in gcc counts the return statement twice in rcpp.cc:32.
+  # Let's standardize it to 2 hits for all toolchains.
+  sed -i'.bak' 's@<line number="32" hits="4"@<line number="32" hits="2"@' "${actual}"
   if ! diff -q "${expected}" "${actual}" >/dev/null; then
     echo "==="
     echo "COVERAGE: ${expected} actual"

--- a/tests/coverage/default_instrumented.xml
+++ b/tests/coverage/default_instrumented.xml
@@ -3,9 +3,10 @@
   <sources>
     <source>exampleC/R/fn.R</source>
     <source>exampleC/R/proto.R</source>
+    <source>exampleC/R/rcpp.R</source>
     <source>exampleC/src/fn.c</source>
     <source>exampleC/src/fn.h</source>
-    <source>exampleC/src/lib/getCharacter.c</source>
+    <source>exampleC/src/rcpp.cc</source>
   </sources>
   <packages>
     <package name="NULL" line-rate="1" branch-rate="0" complexity="0">
@@ -40,6 +41,24 @@
             <line number="19" hits="2" branch="false"/>
           </lines>
         </class>
+        <class name="rcpp.R" filename="exampleC/R/rcpp.R" line-rate="1" branch-rate="0" complexity="0">
+          <methods>
+            <method name="rcppHello" signature="NA" line-rate="1" branch-rate="0">
+              <lines>
+                <line number="16" hits="2" branch="false"/>
+              </lines>
+            </method>
+            <method name="rcppHelloWrapped" signature="NA" line-rate="1" branch-rate="0">
+              <lines>
+                <line number="20" hits="2" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="16" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="false"/>
+          </lines>
+        </class>
         <class name="fn.c" filename="exampleC/src/fn.c" line-rate="1" branch-rate="0" complexity="0">
           <methods>
             <method name="NA" signature="NA" line-rate="NA" branch-rate="0">
@@ -65,14 +84,19 @@
             <line number="22" hits="1" branch="false"/>
           </lines>
         </class>
-        <class name="getCharacter.c" filename="exampleC/src/lib/getCharacter.c" line-rate="1" branch-rate="0" complexity="0">
+        <class name="rcpp.cc" filename="exampleC/src/rcpp.cc" line-rate="1" branch-rate="0" complexity="0">
           <methods>
             <method name="NA" signature="NA" line-rate="NA" branch-rate="0">
               <lines/>
             </method>
           </methods>
           <lines>
-            <line number="17" hits="1" branch="false"/>
+            <line number="21" hits="2" branch="false"/>
+            <line number="22" hits="2" branch="false"/>
+            <line number="23" hits="2" branch="false"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="false"/>
+            <line number="32" hits="2" branch="false"/>
           </lines>
         </class>
       </classes>

--- a/tests/coverage/workspace_instrumented.xml
+++ b/tests/coverage/workspace_instrumented.xml
@@ -5,9 +5,10 @@
     <source>exampleB/R/fn.R</source>
     <source>exampleC/R/fn.R</source>
     <source>exampleC/R/proto.R</source>
+    <source>exampleC/R/rcpp.R</source>
     <source>exampleC/src/fn.c</source>
     <source>exampleC/src/fn.h</source>
-    <source>exampleC/src/lib/getCharacter.c</source>
+    <source>exampleC/src/rcpp.cc</source>
   </sources>
   <packages>
     <package name="NULL" line-rate="1" branch-rate="0" complexity="0">
@@ -66,6 +67,24 @@
             <line number="19" hits="2" branch="false"/>
           </lines>
         </class>
+        <class name="rcpp.R" filename="exampleC/R/rcpp.R" line-rate="1" branch-rate="0" complexity="0">
+          <methods>
+            <method name="rcppHello" signature="NA" line-rate="1" branch-rate="0">
+              <lines>
+                <line number="16" hits="2" branch="false"/>
+              </lines>
+            </method>
+            <method name="rcppHelloWrapped" signature="NA" line-rate="1" branch-rate="0">
+              <lines>
+                <line number="20" hits="2" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="16" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="false"/>
+          </lines>
+        </class>
         <class name="fn.c" filename="exampleC/src/fn.c" line-rate="1" branch-rate="0" complexity="0">
           <methods>
             <method name="NA" signature="NA" line-rate="NA" branch-rate="0">
@@ -91,14 +110,19 @@
             <line number="22" hits="1" branch="false"/>
           </lines>
         </class>
-        <class name="getCharacter.c" filename="exampleC/src/lib/getCharacter.c" line-rate="1" branch-rate="0" complexity="0">
+        <class name="rcpp.cc" filename="exampleC/src/rcpp.cc" line-rate="1" branch-rate="0" complexity="0">
           <methods>
             <method name="NA" signature="NA" line-rate="NA" branch-rate="0">
               <lines/>
             </method>
           </methods>
           <lines>
-            <line number="17" hits="1" branch="false"/>
+            <line number="21" hits="2" branch="false"/>
+            <line number="22" hits="2" branch="false"/>
+            <line number="23" hits="2" branch="false"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="false"/>
+            <line number="32" hits="2" branch="false"/>
           </lines>
         </class>
       </classes>

--- a/tests/exampleC/BUILD
+++ b/tests/exampleC/BUILD
@@ -22,6 +22,7 @@ PKG_SRCS = glob(
     ["**"],
     exclude = [
         "BUILD",
+        "lib/**",  # Handled through cc_library.
     ],
 )
 
@@ -40,6 +41,7 @@ r_pkg(
     # Override default to build package vignettes and manuals.
     # Note that we have a custom Makefile to create dummy HTMLs as vignettes.
     build_args = [],
+    cc_deps = [":cc_lib"],
     deps = PKG_DEPS,
 )
 
@@ -61,4 +63,20 @@ r_pkg_test(
     timeout = "short",
     pkg = PKG_NAME,
     suggested_deps = PKG_CHECK_DEPS,
+)
+
+cc_library(
+    name = "cc_lib",
+    srcs = [
+        "src/lib/getCharacter.c",
+        "src/lib/rcpp.cc",
+    ],
+    hdrs = ["src/lib/rcpp.h"],
+    copts = select({
+        "@platforms//os:macos": ["-isystem /Library/Frameworks/R.framework/Headers"],
+        # symlinked from /usr/share/R/include to work with default cxx_builtin_include_directories
+        "@platforms//os:linux": ["-isystem /usr/include/R"],
+    }) + ["-Wno-unused-variable"],
+    strip_include_prefix = "src",
+    deps = ["@R_Rcpp//:Rcpp.cc"],
 )

--- a/tests/exampleC/R/rcpp.R
+++ b/tests/exampleC/R/rcpp.R
@@ -1,4 +1,4 @@
-# Copyright 2018 The Bazel Authors.
+# Copyright 2021 The Bazel Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,4 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-OBJECTS = fn.o lib/getCharacter.o
+rcppHello <- function() {
+  .Call("rcppHello", PACKAGE = "exampleC")
+}
+
+rcppHelloWrapped <- function() {
+  .Call("rcppHelloWrapped", PACKAGE = "exampleC")
+}

--- a/tests/exampleC/src/lib/rcpp.cc
+++ b/tests/exampleC/src/lib/rcpp.cc
@@ -1,0 +1,12 @@
+#include "lib/rcpp.h"
+
+// Function meant to be used in R Package C++ code.
+Rcpp::StringVector hello() {
+  Rcpp::StringVector v = {"hello", "world"};
+  return v;
+}
+
+// Function meant to be used in R Package R code.
+extern "C" {
+SEXP rcppHello() { return Rcpp::wrap(hello()); }
+}  // "C"

--- a/tests/exampleC/src/lib/rcpp.h
+++ b/tests/exampleC/src/lib/rcpp.h
@@ -1,0 +1,3 @@
+#include <Rcpp.h>
+
+Rcpp::StringVector hello();

--- a/tests/exampleC/src/rcpp.cc
+++ b/tests/exampleC/src/rcpp.cc
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Bazel Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/rcpp.h"
+#include "Rcpp.h"
+
+extern "C" {
+SEXP rcppHelloWrapped() {
+  Rcpp::StringVector v = hello();
+  v.push_back("from");
+  v.push_back("me");
+  v.push_back("too");
+  // Have the closing parenthesis in the same line as the return statement
+  // because coverage profile from gcc and llvm toolchains differ in how they
+  // assign coverage to the closing parenthesis. This enables us to use the
+  // same golden coverage file in our tests for both gcc and llvm, and just
+  // fix this one line. See coverage_test.sh.
+  // clang-format off
+  return Rcpp::wrap(v); }
+// clang-format on
+}  // "C"

--- a/tests/exampleC/tests/test.R
+++ b/tests/exampleC/tests/test.R
@@ -21,5 +21,11 @@
 # //exampleB, and should be absent otherwise.
 stopifnot(identical(c("A", "B"), exampleB::exampleB()))
 
-# Coverage from these proto.R will have 2 hits.
+# Coverage from proto.R will have 2 hits.
 stopifnot(exampleC::proto()$id == 7)
+
+# Coverage from rcpp.R will have 2 hits.
+stopifnot(identical(c("hello", "world"), exampleC::rcppHello()))
+
+# Coverage from rcpp.R will have 2 hits.
+stopifnot(identical(c("hello", "world", "from", "me", "too"), exampleC::rcppHelloWrapped()))

--- a/tests/exampleC/tests/testthat/test_cc_deps.R
+++ b/tests/exampleC/tests/testthat/test_cc_deps.R
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# test cc_deps in the RProtoBuf package.
 test_that("cc_deps", {
   expect_equal(7, proto()$id)
+})
+
+# test cc_import for the .so file in the Rcpp package.
+test_that("cc_import", {
+  expect_equal(c("hello", "world"), exampleC::rcppHello())
+  expect_equal(c("hello", "world", "from", "me", "too"), exampleC::rcppHelloWrapped())
 })

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,10 +17,14 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-echo "::group::Setting up bazel"
+echo "::group::Setting up"
 source "./setup-bazel.sh"
 "${bazel}" clean
 "${bazel}" version
+if [[ "$(uname)" == "Linux" ]] && ! [[ -d "/usr/include/R" ]]; then
+  # exampleC:cc_lib needs a symlink for R include directory.
+  sudo ln -s "$(Rscript -e 'cat(R.home("include"))')" "/usr/include/R"
+fi
 echo "::endgroup::"
 
 echo "::group::Binary tests"


### PR DESCRIPTION
We start generating `cc_library` targets in razel that take in the .so
file from the built package and any included headers.

Such targets can be used to write C++ code that depend on other R
packages like Rcpp. This C++ code can be compiled with bazel and
will benefit from the bazel C++ toolchain configuration, parallelism and
granular caching. The C++ code in turn can then be used inside
another R package through the `cc_deps` attribute.

Fixes #57.