### PR TITLE
Set PKG_ vars for cc_deps in the site Makevars file

### DIFF
--- a/tests/exampleC/src/Makevars
+++ b/tests/exampleC/src/Makevars
@@ -1,0 +1,18 @@
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Specify empty PKG_LIBS and PKG_CPPFLAGS to check if we can append to an
+# existing list, instead of being overwritten by the empty list.
+PKG_LIBS = 
+PKG_CPPFLAGS = 


### PR DESCRIPTION
Package src/Makevars files typically use the `=` assignment because `+=` and `:=` are both GNU extensions. Which means that the environment variable values are overwritten by the user-defined list in the package src/Makevars.

By using the site Makevars file with the `+=` assignment, we can ensure that we append to any user-specified list in src/Makevars, and that our values are not overwritten by the user-specified list. Because site Makevars file is processed after the package src/Makevars file.

Fixes #63.