### PR TITLE
Coverage for cc_deps

### DIFF
--- a/R/dependencies.bzl
+++ b/R/dependencies.bzl
@@ -32,7 +32,7 @@ load(
 r_coverage_dependencies = _r_coverage_dependencies
 
 def r_rules_dependencies():
-    _is_at_least("3.0.0", native.bazel_version)
+    _is_at_least("3.5.0", native.bazel_version)
 
     # TODO: Use bazel-skylib directly instead of replicating functionality when
     # nested workspaces become a reality.  Otherwise, dependencies will need to

--- a/R/internal/common.bzl
+++ b/R/internal/common.bzl
@@ -36,6 +36,13 @@ def tests_dir(pkg_dir):
         return "tests"
     return pkg_dir + "/tests"
 
+def srcs_dir(pkg_dir):
+    # Standard srcs directory within a package.
+
+    if pkg_dir == ".":
+        return "src"
+    return pkg_dir + "/src"
+
 def env_vars(env_vars):
     # Array of commands to export environment variables.
 
@@ -83,18 +90,17 @@ def library_deps(target_deps):
 
     # Individual R library directories.
     lib_dirs = []
-    gcno_dirs = []
-
+    gcno_files = []
     for pkg_dep in transitive_pkg_deps.to_list():
         lib_dirs.append(pkg_dep.pkg_lib_dir)
-        if pkg_dep.pkg_gcno_dir:
-            gcno_dirs.append(pkg_dep.pkg_gcno_dir)
+        if pkg_dep.pkg_gcno_files:
+            gcno_files.extend(pkg_dep.pkg_gcno_files)
 
     return struct(
-        gcno_dirs = gcno_dirs,
         lib_dirs = lib_dirs,
         transitive_pkg_deps = transitive_pkg_deps,
         transitive_tools = transitive_tools,
+        gcno_files = gcno_files,
     )
 
 def layer_library_deps(ctx, library_deps):

--- a/R/internal/makevars/Makevars.darwin.sh
+++ b/R/internal/makevars/Makevars.darwin.sh
@@ -35,6 +35,9 @@ while getopts "b" opt; do
   esac
 done
 
+# Override the flag value with user-provided env var.
+BREW="${BAZEL_R_HOMEBREW:-"${BREW}"}"
+
 sysroot="$(xcrun --show-sdk-path)"
 
 export HOME=/tmp  # Needed for Homebrew.

--- a/R/internal/makevars/darwin.bzl
+++ b/R/internal/makevars/darwin.bzl
@@ -48,7 +48,9 @@ local_darwin_makevars = repository_rule(
         ),
         "check_homebrew_llvm": attr.bool(
             default = True,
-            doc = "Use Homebrew LLVM if installed.",
+            doc = ("Use Homebrew LLVM if installed. Can be overridden by " +
+                   "setting the environment variable BAZEL_R_HOMEBREW to " +
+                   "true or false."),
         ),
         "_processor": attr.label(
             default = "@com_grail_rules_r//R/internal/makevars:Makevars.darwin.sh",
@@ -63,7 +65,7 @@ local_darwin_makevars = repository_rule(
            "Also symlinks llvm-cov to be used as a tool in the toolchain " +
            "so that it can be used when collecting coverage."),
     configure = True,
-    environ = ["PATH"],
+    environ = ["PATH", "BAZEL_R_HOMEBREW"],
     local = True,
     implementation = _local_darwin_makevars_impl,
 )

--- a/R/providers.bzl
+++ b/R/providers.bzl
@@ -27,7 +27,8 @@ RPackage = provider(
         "build_tools": "tools needed to build this package",
         "makevars": "User level makevars file for native code compilation",
         "cc_deps": "cc_deps struct for the package",
-        "pkg_gcno_dir": "Directory containing instrumented gcno files",
+        # https://github.com/bazelbuild/bazel/issues/13292
+        "pkg_gcno_files": ".gcno files generated during instrumentation",
         "external_repo": "Boolean indicating if the package is from an external repo",
     },
 )

--- a/R/scripts/build.sh
+++ b/R/scripts/build.sh
@@ -303,13 +303,10 @@ mv "${PKG_NAME}"*gz "${PKG_BIN_ARCHIVE}"  # .tgz on macOS and .tar.gz on Linux.
 
 if "${INSTRUMENTED}"; then
   add_instrumentation_hook
-  # Copy native code instrumentation files into a separate directory.
-  # Note that we used `--clean` option during `R CMD INSTALL` so typical
-  # intermediate files like .o, .so, etc. have been deleted, but .gcno
-  # and .gcda files have not been deleted.
+  # Copy .gcno files next to the source files.
   if [[ -d "${TMP_SRC}/src" ]]; then
-    find "${TMP_SRC}/src" -name '*.gcda' -delete
-    cp -a -L "${TMP_SRC}/src" "$(dirname "${PKG_LIB_PATH}")"
+    rsync -am --include='*.gcno' --include='*/' --exclude='*' \
+      "${TMP_SRC}/src" "$(dirname "${PKG_LIB_PATH}")"
   fi
 fi
 

--- a/R/scripts/test.sh.tpl
+++ b/R/scripts/test.sh.tpl
@@ -59,17 +59,7 @@ pushd ${TEST_TMPDIR} >/dev/null
 # Set up the code coverage environment
 if "{collect_coverage}"; then
   export R_COVR=true  # As exported by covr
-  gcov_prefix_strip() {
-    # TODO: Find a better way of determining components to strip.
-    {Rscript} - <<EOF
-path <- normalizePath('/tmp/bazel/R/src')
-n <- length(strsplit(path, '/')[[1]]) - 1
-if (startsWith(Sys.getenv('TEST_TARGET'), '@')) n <- n + 2
-cat(n)
-EOF
-  }
-  GCOV_PREFIX_STRIP="$(gcov_prefix_strip)"
-  export GCOV_PREFIX_STRIP
+  export GCOV_PREFIX_STRIP=0  # We strip later depending on the source of the .gcda file.
   export GCOV_EXIT_AT_ERROR=1
 fi
 
@@ -97,6 +87,7 @@ if ls *.[Rr] > /dev/null 2>&1; then
 fi
 
 popd > /dev/null
+
 if "{collect_coverage}"; then
   {Rscript} "${RUNFILES_DIR}/{collect_coverage.R}"
 fi

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ load("@com_grail_rules_r//R:defs.bzl", "r_package_with_test")
 
 The following software must be installed on your system:
 
-    1. bazel (v3.0.0 or above)
+    1. bazel (v3.5.0 or above)
     2. R (3.4.3 or above; should be locatable using the `PATH` environment variable)
 
 **NOTE**: After re-installing or upgrading R, please reset the registered

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,1 +1,2 @@
 build --workspace_status_command=stamping/workspace_status.sh
+build --incompatible_strict_action_env

--- a/tests/coverage/coverage_test.sh
+++ b/tests/coverage/coverage_test.sh
@@ -105,6 +105,8 @@ echo ""
 echo "=== Testing custom toolchain ==="
 if [[ "$(uname)" == "Linux" ]] && ! "${CI:-"false"}"; then
   # Check if we can compute coverage using supplied LLVM tools.
+  # Note that this toolchain is currently not producing .gcda files, so
+  # coverage from cc_deps is missing.
   echo "Checking coverage results with the LLVM toolchain:"
   toolchain_args=(
     "--extra_toolchains=//:toolchain-linux"
@@ -113,6 +115,6 @@ if [[ "$(uname)" == "Linux" ]] && ! "${CI:-"false"}"; then
     "--toolchain_resolution_debug"
   )
   "${bazel}" coverage "${bazel_test_opts[@]}" "${toolchain_args[@]}" //packages/exampleC:test
-  expect_equal "default_instrumented.xml" "${coverage_file}"
+  expect_equal "custom_toolchain.xml" "${coverage_file}"
 fi
 echo "Done!"

--- a/tests/coverage/coverage_test.sh
+++ b/tests/coverage/coverage_test.sh
@@ -35,6 +35,16 @@ version_info="$($(R CMD config CC) --version)"
 echo "Checking coverage results with the following system compiler:"
 echo "${version_info}"
 
+# Ensure that we are using the same compiler for both cc_library and for R.
+# This is usually a problem when our default local toolchain for R on macOS
+# picks the homebrew LLVM compiler but bazel's C++ toolchain is using the Apple
+# toolchain. When object files from two different compilers is used in the same
+# run, .gcda files will be generated without version information and will be
+# considered invalid by gcov.
+if [[ "$(uname)" == "Darwin" ]]; then
+  export BAZEL_R_HOMEBREW=false
+fi
+
 testlogs="$("${bazel}" info bazel-testlogs)"
 readonly testlogs
 readonly coverage_file="${testlogs}/packages/exampleC/test/coverage.dat"

--- a/tests/coverage/custom_toolchain.xml
+++ b/tests/coverage/custom_toolchain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage line-rate="1" branch-rate="0" lines-covered="25" lines-valid="25" branches-covered="0" branches-valid="0" complexity="0" version="3.5.1" timestamp="1960-01-01 00:00:00">
+<coverage line-rate="1" branch-rate="0" lines-covered="20" lines-valid="20" branches-covered="0" branches-valid="0" complexity="0" version="3.5.1" timestamp="1960-01-01 00:00:00">
   <sources/>
   <packages>
     <package name="NULL" line-rate="1" branch-rate="0" complexity="0">
@@ -67,21 +67,6 @@
           <methods/>
           <lines>
             <line number="22" hits="1" branch="false"/>
-          </lines>
-        </class>
-        <class name="getCharacter.c" filename="packages/exampleC/src/lib/getCharacter.c" line-rate="1" branch-rate="0" complexity="0">
-          <methods/>
-          <lines>
-            <line number="17" hits="1" branch="false"/>
-          </lines>
-        </class>
-        <class name="rcpp.cc" filename="packages/exampleC/src/lib/rcpp.cc" line-rate="1" branch-rate="0" complexity="0">
-          <methods/>
-          <lines>
-            <line number="20" hits="4" branch="false"/>
-            <line number="21" hits="4" branch="false"/>
-            <line number="28" hits="4" branch="false"/>
-            <line number="33" hits="2" branch="false"/>
           </lines>
         </class>
         <class name="rcpp.cc" filename="packages/exampleC/src/rcpp.cc" line-rate="1" branch-rate="0" complexity="0">

--- a/tests/coverage/workspace_instrumented.xml
+++ b/tests/coverage/workspace_instrumented.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage line-rate="1" branch-rate="0" lines-covered="22" lines-valid="22" branches-covered="0" branches-valid="0" complexity="0" version="3.5.1" timestamp="1960-01-01 00:00:00">
+<coverage line-rate="1" branch-rate="0" lines-covered="27" lines-valid="27" branches-covered="0" branches-valid="0" complexity="0" version="3.5.1" timestamp="1960-01-01 00:00:00">
   <sources/>
   <packages>
     <package name="NULL" line-rate="1" branch-rate="0" complexity="0">
@@ -91,6 +91,21 @@
           <methods/>
           <lines>
             <line number="22" hits="1" branch="false"/>
+          </lines>
+        </class>
+        <class name="getCharacter.c" filename="packages/exampleC/src/lib/getCharacter.c" line-rate="1" branch-rate="0" complexity="0">
+          <methods/>
+          <lines>
+            <line number="17" hits="1" branch="false"/>
+          </lines>
+        </class>
+        <class name="rcpp.cc" filename="packages/exampleC/src/lib/rcpp.cc" line-rate="1" branch-rate="0" complexity="0">
+          <methods/>
+          <lines>
+            <line number="20" hits="4" branch="false"/>
+            <line number="21" hits="4" branch="false"/>
+            <line number="28" hits="4" branch="false"/>
+            <line number="33" hits="2" branch="false"/>
           </lines>
         </class>
         <class name="rcpp.cc" filename="packages/exampleC/src/rcpp.cc" line-rate="1" branch-rate="0" complexity="0">

--- a/tests/packages/exampleC/src/lib/rcpp.cc
+++ b/tests/packages/exampleC/src/lib/rcpp.cc
@@ -19,8 +19,14 @@ limitations under the License.
 // Function meant to be used in R Package C++ code.
 Rcpp::StringVector hello() {
   Rcpp::StringVector v = {"hello", "world"};
-  return v;
-}
+  // Have the closing parenthesis in the same line as the return statement
+  // because coverage profile from gcc and llvm toolchains differ in how they
+  // assign coverage to the closing parenthesis. This enables us to use the
+  // same golden coverage file in our tests for both gcc and llvm, and just
+  // fix this one line. See coverage_test.sh.
+  // clang-format off
+  return v; }
+// clang-format on
 
 // Function meant to be used in R Package R code.
 extern "C" {


### PR DESCRIPTION
Includes some overhaul in our coverage collection code to be able to also get the profiles from cc_deps dependencies.

Note that the compiler used by R and the compiler used by the C++ rules will need to be identical for the .gcda files to be valid.