### PR TITLE
Use single library directory

### DIFF
--- a/R/scripts/build_pkg_bin.sh
+++ b/R/scripts/build_pkg_bin.sh
@@ -19,7 +19,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/build_pkg_common.sh"
 
 mkdir -p "${PKG_LIB_PATH}"
 
-export R_LIBS="${R_LIBS_DEPS//_EXEC_ROOT_/${EXEC_ROOT}/}"
+symlink_r_libs "${R_LIBS_DEPS//_EXEC_ROOT_/${EXEC_ROOT}/}"
 
 tar -C "${TMP_SRC}" --strip-components=1 -xzf "${PKG_SRC_ARCHIVE}"
 

--- a/R/scripts/build_pkg_src.sh
+++ b/R/scripts/build_pkg_src.sh
@@ -88,9 +88,8 @@ if [[ "${C_SO_FILES}" ]]; then
   fi
 fi
 
-export R_LIBS="${R_LIBS_ROCLETS//_EXEC_ROOT_/${EXEC_ROOT}/}"
-
 if [[ "${ROCLETS}" ]]; then
+  symlink_r_libs "${R_LIBS_ROCLETS//_EXEC_ROOT_/${EXEC_ROOT}/}"
   silent "${RSCRIPT}" - <<EOF
 bazel_libs <- .libPaths()
 bazel_libs <- bazel_libs[! bazel_libs %in% c(.Library, .Library.site)]
@@ -102,9 +101,7 @@ if ("devtools" %in% installed.packages(bazel_libs)[, "Package"]) {
 EOF
 fi
 
-mkdir -p "${PKG_LIB_PATH}"
-
-export R_LIBS="${R_LIBS_DEPS//_EXEC_ROOT_/${EXEC_ROOT}/}"
+symlink_r_libs "${R_LIBS_DEPS//_EXEC_ROOT_/${EXEC_ROOT}/}"
 
 silent "${R}" CMD build "${BUILD_ARGS}" "${TMP_SRC}"
 mv "${PKG_NAME}"*.tar.gz "${TMP_SRC_TAR}"

--- a/R/scripts/collect_coverage.R
+++ b/R/scripts/collect_coverage.R
@@ -96,7 +96,6 @@ local({
     strip <- 6 # [sandbox_number] + execroot + [test_workspace] + bazel-out + darwin-* + bin
   }
   cc_dep_coverage_dir <- file.path(coverage_dir, prefix)
-
   copy_gcda(cc_dep_coverage_dir, strip)
 })
 
@@ -108,14 +107,27 @@ if (bazel_r_debug) {
 # Obtain paths to packages as the compiler was invoked in these directories and so
 # gcno files have embedded paths to source files relative to these directories.
 pkg_paths <- local({
-  lib_paths <- strsplit(Sys.getenv("R_LIBS"), ':')[[1]]
-  pkg_libs <- installed.packages(lib.loc=lib_paths)[, "LibPath"]
-  pkg_libs <- sub(paste0("^", getwd(), "/"), "", pkg_libs)
-  pkg_libs <- sub(paste0("^../", test_workspace, "/"), "", pkg_libs)
-  pkg_libs <- Filter(function(x) !startsWith(x, "../"), pkg_libs)  # Filter external packages.
-
-  pkg_names <- names(pkg_libs)
-  dirname(pkg_libs)
+  pkgs <- list.files(Sys.getenv("R_LIBS_USER"), full.names = TRUE)
+  pkgs <- normalizePath(pkgs) # Resolve symlinks.
+  pkg_libs <- dirname(pkgs) # Individual lib directories of packages.
+  pkg_paths <- dirname(pkg_libs) # Path to bazel packages.
+  # Get paths relative to cwd.
+  wd <- paste0(getwd(), "/")
+  wd_parent <- paste0(dirname(wd), "/")
+  pkg_paths <- sapply(pkg_paths, function(path) {
+    if (startsWith(path, wd)) {
+      # Package belongs to this workspace; do nothing.
+      return(sub(wd, "", path))
+    } else if (startsWith(path, wd_parent)) {
+      # Package belongs to an external workspace; replace path to external/...
+      return(sub(wd_parent, "external/", path))
+    } else {
+      stop("unrecognized R package path: ", path)
+    }
+  })
+  pkg_names <- basename(pkgs)
+  names(pkg_paths) <- pkg_names
+  return(pkg_paths)
 })
 
 # Try the given gcov command, returning TRUE or FALSE indicating success.


### PR DESCRIPTION
Instead of using long library search paths, use a single library
directory as R_LIBS_USER.

R_LIBS_USER and R_LIBS are subjected to parameter substitution in some
systems (e.g. Ubuntu) in the Renviron file, and are not robust to very
long strings.

Fixes #51.