### PR TITLE
Better reproducibility of native code

### DIFF
--- a/R/dependencies.bzl
+++ b/R/dependencies.bzl
@@ -21,6 +21,10 @@ load(
     _local_darwin_makevars = "local_darwin_makevars",
 )
 load(
+    "@com_grail_rules_r//R/internal/makevars:linux.bzl",
+    _local_linux_makevars = "local_linux_makevars",
+)
+load(
     "@com_grail_rules_r//R/internal/toolchains:local_toolchain.bzl",
     _local_r_toolchain = "local_r_toolchain",
 )
@@ -41,6 +45,10 @@ def r_rules_dependencies():
     _maybe(
         _local_darwin_makevars,
         name = "com_grail_rules_r_makevars_darwin",
+    )
+    _maybe(
+        _local_linux_makevars,
+        name = "com_grail_rules_r_makevars_linux",
     )
 
 def r_register_toolchains(**kwargs):

--- a/R/internal/makevars/Makevars.linux.sh
+++ b/R/internal/makevars/Makevars.linux.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [[ $(uname -s) != "Linux" ]]; then
+  exit
+fi
+
+warn() {
+  >&2 echo "WARNING: $*"
+}
+
+error() {
+  >&2 echo "ERROR: $*"
+}
+
+# Allow user to specify where to find R.
+if ! [[ "${BAZEL_R_HOME:-}" ]]; then
+  BAZEL_R_HOME="$(R RHOME)"
+fi
+
+# Determine if the default compiler is gcc.
+is_gcc=0
+cc="$("${BAZEL_R_HOME}/bin/R" CMD config CC)"
+cc_version="$(${cc} --version | head -n1)"
+if [[ "${cc_version}" == "gcc"* ]]; then
+  is_gcc=1
+fi
+
+cppflags=""
+if (( is_gcc )); then
+  # Additional gcc specific flags.
+  cppflags="-fno-canonical-system-headers"
+fi
+
+subst=(
+'s|@CPPFLAGS@|'"${cppflags}"'|g;'
+)
+sed -e "${subst[*]}"

--- a/R/internal/makevars/Makevars.linux.tpl
+++ b/R/internal/makevars/Makevars.linux.tpl
@@ -1,4 +1,4 @@
-# Copyright 2018 The Bazel Authors.
+# Copyright 2021 The Bazel Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,29 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# macOS specific overrides
-# See https://cran.r-project.org/doc/manuals/R-admin.html#macOS-packages
-
-# gfortran paths when installed as part of `brew install gcc`
-# If F77 is empty, it is because gfortran was not found.
-# If FLIBS search path is empty, it is because libgfortran was not found.
-F77=@GFORTRAN@
-FC=${F77}
-FLIBS=-L@GCC_LIB_PATH@ -lgfortran -lquadmath -lm
-
-CC = @CC@
-CXX = @CXX@
-CPPFLAGS = @CPPFLAGS@
-LDFLAGS = @LDFLAGS@
-
 # Flags for reproducible builds.
 CPPFLAGS += "-Wno-builtin-macro-redefined" \
   "-D__DATE__=\"redacted\"" \
   "-D__TIMESTAMP__=\"redacted\"" \
   "-D__TIME__=\"redacted\"" \
   "-fdebug-prefix-map=_EXEC_ROOT_=" \
-  "-fmacro-prefix-map=_EXEC_ROOT_=" \
+  "-fmacro-prefix-map=_EXEC_ROOT_="
 
-# Apple's compilers from Command Line Tools do not have OpenMP support
-SHLIB_OPENMP_CFLAGS = @OPENMP_FLAGS@
-SHLIB_OPENMP_CXXFLAGS = @OPENMP_FLAGS@
+CPPFLAGS += @CPPFLAGS@

--- a/R/internal/makevars/linux.bzl
+++ b/R/internal/makevars/linux.bzl
@@ -1,0 +1,64 @@
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@com_grail_rules_r//internal:shell.bzl",
+    _sh_quote = "sh_quote",
+)
+
+def _local_linux_makevars_impl(rctx):
+    process_script = "exec {processor} < {src} > {out}".format(
+        processor = _sh_quote(rctx.path(rctx.attr._processor)),
+        src = _sh_quote(rctx.path(rctx.attr.src)),
+        out = _sh_quote(rctx.name),
+    )
+
+    rctx.file("process.sh", content = process_script)
+
+    exec_result = rctx.execute(["./process.sh"], environment = rctx.attr.env)
+    if exec_result.return_code:
+        fail("Failed to process file: %s\n%s" % (exec_result.stdout, exec_result.stderr))
+    if exec_result.stderr:
+        print(exec_result.stderr)
+
+    rctx.file("BUILD", content = ('exports_files(["%s"])' % rctx.name))
+    return
+
+local_linux_makevars = repository_rule(
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            default = "@com_grail_rules_r//R/internal/makevars:Makevars.linux.tpl",
+            doc = "Template Makevars file.",
+        ),
+        "env": attr.string_dict(
+            doc = "Environment variables to provide to processor.",
+        ),
+        "_processor": attr.label(
+            default = "@com_grail_rules_r//R/internal/makevars:Makevars.linux.sh",
+            doc = ("Processor script to perform template substitution. " +
+                   "Takes input file as STDIN and returns the processed " +
+                   "file as STDOUT. May perform side actions in the " +
+                   "workspace directory to create more files."),
+        ),
+    },
+    doc = ("Repository rule to create a Makevars file for macOS that can " +
+           "check for Homebrew LLVM and set compiler paths accordingly. " +
+           "Also symlinks llvm-cov to be used as a tool in the toolchain " +
+           "so that it can be used when collecting coverage."),
+    configure = True,
+    environ = ["PATH", "BAZEL_R_HOME"],
+    local = True,
+    implementation = _local_linux_makevars_impl,
+)

--- a/R/internal/toolchains/local_toolchain.bzl
+++ b/R/internal/toolchains/local_toolchain.bzl
@@ -109,12 +109,14 @@ def _local_r_toolchain_impl(rctx):
 
     makevars_site_str = "None"
     tools = list(rctx.attr.tools)
-    if rctx.attr.makevars_site and detect_os(rctx) == "darwin":
-        makevars_site_str = "\"@com_grail_rules_r_makevars_darwin\""
-        llvm_cov_dir = rctx.path(Label("@com_grail_rules_r_makevars_darwin")).dirname
+    if rctx.attr.makevars_site:
+        os = detect_os(rctx)
+        makevars_repo = "@com_grail_rules_r_makevars_%s" % os
+        makevars_site_str = "\"%s\"" % makevars_repo
+        llvm_cov_dir = rctx.path(Label(makevars_repo)).dirname
         llvm_cov_path = llvm_cov_dir.get_child("llvm-cov")
         if llvm_cov_path.exists:
-            llvm_cov = Label("@com_grail_rules_r_makevars_darwin//:llvm-cov")
+            llvm_cov = Label("%s//:llvm-cov" % makevars_repo)
             tools.append(llvm_cov)
 
     state_file = "system_state.txt"

--- a/R/scripts/build_pkg_common.sh
+++ b/R/scripts/build_pkg_common.sh
@@ -135,16 +135,6 @@ if [[ "${R_MAKEVARS_USER:-}" ]]; then
   export R_MAKEVARS_USER="${tmp_mkvars}"
 fi
 
-# Override flags to the compiler for reproducible builds.
-repro_flags=(
-"-Wno-builtin-macro-redefined"
-"-D__DATE__=\"redacted\""
-"-D__TIMESTAMP__=\"redacted\""
-"-D__TIME__=\"redacted\""
-"-fdebug-prefix-map=\"${EXEC_ROOT}/=\""
-)
-echo "CPPFLAGS += ${repro_flags[*]}" >> "${R_MAKEVARS_SITE}"
-
 # Get any flags from cc_deps for this package and append to site Makevars file.
 # We keep these last in the site Makevars files so that any flags here may take
 # precedence over other conflicting settings specified previously in the file.
@@ -163,13 +153,14 @@ fi
 # with their individual directories because on some sytems (e.g., Ubuntu),
 # R_LIBS_USER and R_LIBS are parameter substituted with a default in .Renviron,
 # which imposes length limits.
+# For reproducibility of embedded paths in compiled native code when using
+# "Linking To" type dependencies, use a constant path for this library
+# directory.
 
 # Hide R_LIBS from R to prevent packages in here from being picked up, and use
 # R_LIBS_USER to stage our packages.
 export R_LIBS=dummy
-R_LIBS_USER="$(mktemp -d)"
-TMP_SRCS+=("${R_LIBS_USER}")
-export R_LIBS_USER
+export R_LIBS_USER="${TMP_LIB}"
 
 symlink_r_libs() {
   local r_libs="${1}"


### PR DESCRIPTION
We notice that in repro tests run locally, we were using a remote cache,
and so were not properly testing for reproducibility.

After fixing the test, we discovered that were not using
`-fno-canonical-system-headers` for gcc which was embedding paths of
cc_deps header directories in compiled .so files. When using headers
from R's "Linking To" type dependencies, the library directory where the
directory is installed needs to be a constant path, or the path needs to
be added to -fdebug-prefix-map options.