### PR TITLE
Stamp DESCRIPTION file in a separate step

### DIFF
--- a/R/scripts/build_pkg_src.sh
+++ b/R/scripts/build_pkg_src.sh
@@ -43,27 +43,6 @@ copy_cmd+=("${EXEC_ROOT}/${PKG_SRC_DIR}/" "${TMP_SRC}")
 "${copy_cmd[@]}"
 TMP_FILES+=("${TMP_SRC}")
 
-# Make a script file for sed that can substitute status vars enclosed in {}, with their values.
-status_substitution_commands="$(mktemp)"
-TMP_FILES+=("${status_substitution_commands}")
-add_substitute_commands() {
-  local status_file="$1"
-  sed -e 's/@/\\@/' -e 's/^/s@{/' -e 's/ /}@/' -e 's/$/@/' "${status_file}" >> "${status_substitution_commands}"
-}
-
-add_metadata() {
-  local IFS=","
-  for status_file in ${STATUS_FILES}; do
-    add_substitute_commands "${status_file}"
-  done
-  for key_value in ${METADATA_MAP:-}; do
-    IFS=":" read -r key value <<< "${key_value}"
-    value=$(echo "${value}" | sed -f "${status_substitution_commands}")
-    printf "%s: %s\n" "${key}" "${value}" >> "${TMP_SRC}/DESCRIPTION"
-  done
-}
-add_metadata
-
 # Hack: copy the .so files inside the package source so that they are installed
 # (in bazel's sandbox as well as on user's system) along with package libs, and
 # use relative rpath (Linux) or change the install name to use @loader_path

--- a/R/scripts/merge_test_files.sh
+++ b/R/scripts/merge_test_files.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+tar -xzf "${IN_TAR}" "${PKG_NAME}/DESCRIPTION"
+
+# Uncompress the original tar.
+new_tar="${IN_TAR}"
+new_tar="${new_tar%.gz}"
+gunzip -c "${IN_TAR}" > "${new_tar}"
+
+# Copy the test files so we can reset their mtime so make the tarball reproducible.
+dir=$(mktemp -d)
+mkdir -p "${dir}"
+rsync --recursive --copy-links --no-perms --chmod=u+w --executability --specials \
+  "${PKG_SRC_DIR}/tests" "${dir}/${PKG_NAME}"
+TZ=UTC find "${dir}" -exec touch -amt 197001010000 {} \+
+
+# Append the files to the tar.
+tar -rf "${new_tar}" -C "${dir}" "${PKG_NAME}/tests"
+rm -rf "${dir}"
+
+# Ask gzip to not store the timestamp.
+gzip --no-name -c "${new_tar}" > "${OUT_TAR}"

--- a/R/scripts/stamp_description.sh
+++ b/R/scripts/stamp_description.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+tar -xzf "${IN_TAR}" "${PKG_NAME}/DESCRIPTION"
+
+# Make a script file for sed that can substitute status vars enclosed in {}, with their values.
+status_substitution_commands="$(mktemp)"
+add_substitute_commands() {
+  local status_file="$1"
+  sed -e 's/@/\\@/' -e 's/^/s@{/' -e 's/ /}@/' -e 's/$/@/' "${status_file}" >> \
+      "${status_substitution_commands}"
+}
+
+add_metadata() {
+  local IFS=","
+  for status_file in ${STATUS_FILES}; do
+    add_substitute_commands "${status_file}"
+  done
+  for key_value in ${METADATA_MAP:-}; do
+    IFS=":" read -r key value <<< "${key_value}"
+    value=$(echo "${value}" | sed -f "${status_substitution_commands}")
+    printf "%s: %s\\n" "${key}" "${value}" >> "${PKG_NAME}/DESCRIPTION"
+  done
+}
+add_metadata
+rm "${status_substitution_commands}"
+
+# Uncompress the original tar.
+new_tar="${IN_TAR}"
+new_tar="${new_tar%.gz}"
+gunzip -c "${IN_TAR}" > "${new_tar}"
+
+# Reset mtime so that tarball is reproducible.
+TZ=UTC touch -amt 197001010000 "${PKG_NAME}/DESCRIPTION"
+# Repackage the DESCRIPTION into the tar.
+tar -rf "${new_tar}" "${PKG_NAME}/DESCRIPTION"
+
+# Compress the tar and ask gzip to not store the timestamp.
+mkdir -p "$(dirname "${OUT_TAR}")"
+gzip --no-name -c "${new_tar}" > "${OUT_TAR}"

--- a/README.md
+++ b/README.md
@@ -429,7 +429,8 @@ the right flags.
       <td>
         <p><code>Bool; default False</code></p>
         <p>Include the stable status file when substituting values in the metadata.
-           The volatile status file is always included.</p>
+           The volatile status file is always included if there is at least one
+           occurrence of `{` that is not followed by `STABLE_`.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
The stamp step is better separate because bazel remote cache treats
volatile status file as part of the action key, and so we want to keep
this step as small as possible and as late as possible.

We can also employ some heuristics like not including the volatile
status file if all of the variables start with STABLE_.