### PR TITLE
Constant volatile status to improve cache hit rate

### DIFF
--- a/R/internal/build.bzl
+++ b/R/internal/build.bzl
@@ -285,10 +285,14 @@ def _stamp_description(ctx, in_tar, out_tar, pkg_name):
         return
 
     # Variables from the volatile status file can not have the prefix STABLE_
-    # because those get routed to the stable status file.
+    # because those get routed to the stable status file. And there are two
+    # special variables that also get routed to the stable status file.
     include_volatile_status_file = False
     for value in ctx.attr.metadata.values():
-        if value.count("{") != value.count("{STABLE_"):
+        stable_vars_count = (value.count("{STABLE_") +
+                             value.count("{BUILD_USER}") +
+                             value.count("{BUILD_HOST}"))
+        if value.count("{") != stable_vars_count:
             include_volatile_status_file = True
             break
 

--- a/tests/stamping/workspace_status.sh
+++ b/tests/stamping/workspace_status.sh
@@ -15,3 +15,10 @@
 
 echo "VAR foo"
 echo "STABLE_VAR bar"
+
+# Replace volatile status variables with constants so that changes to volatile
+# status file do not affect remote cache.
+# https://github.com/bazelbuild/bazel/issues/10075
+echo "BUILD_USER foo"
+echo "BUILD_HOST foo"
+echo "BUILD_TIMESTAMP foo"


### PR DESCRIPTION
bazel remote cache does not respect the intent of volatile status file,
so let's ensure that the status variables are constant in our tests.

https://github.com/bazelbuild/bazel/issues/10075