### PR TITLE
Fix missing binaries in R Nix hermetic env

### DIFF
--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -5,3 +5,5 @@ build --java_runtime_version=remotejdk_11
 build --action_env=ZERO_AR_DATE=1 # https://github.com/bazelbuild/bazel/issues/10886
 
 try-import buildbuddy.bazelrc
+
+build --incompatible_enable_cc_toolchain_resolution

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -98,6 +98,7 @@ r_toolchain(
     tools = [
         "@Rnix//:bin/R",
         "@Rnix//:bin/Rscript",
+        "@rsync//:bin/rsync",
     ],
     version = "4.1",
     visibility = ["//visibility:public"],

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -53,8 +53,14 @@ nixpkgs_package(
     repository = "@nixpkgs",
 )
 
+nixpkgs_package(
+    name = "rsync",
+    attribute_path = "rsync",
+    repository = "@nixpkgs",
+)
+
 # To actually use R from nix, change this value to True.
-use_r_from_nix = False
+use_r_from_nix = True
 
 # Initialize rules_r.
 load("@com_grail_rules_r//R:dependencies.bzl", "r_rules_dependencies")
@@ -166,3 +172,7 @@ llvm_toolchain(
         "linux-x86_64": "stdc++",
     },
 )
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()


### PR DESCRIPTION
First, gcc will complain about missing as inside the environment. So,
register the LLVM toolchain and set new cc resolution.

Second, R build scripts will complaing about missing rsync, so add it
in.