### PR TITLE
Fix r_rules_dependencies() failing in custom builds of Bazel

### DIFF
--- a/R/dependencies.bzl
+++ b/R/dependencies.bzl
@@ -37,7 +37,9 @@ r_coverage_dependencies = _r_coverage_dependencies
 
 def r_rules_dependencies():
     # Keep in sync with README.md and tests.yml.
-    _is_at_least("5.0.0", native.bazel_version)
+    # native.bazel_version is "" in custom builds of Bazel
+    if native.bazel_version != "":
+        _is_at_least("5.0.0", native.bazel_version)
 
     # TODO: Use bazel-skylib directly instead of replicating functionality when
     # nested workspaces become a reality.  Otherwise, dependencies will need to


### PR DESCRIPTION
If you build Bazel with a plain `bazel build //src:bazel` and use `./bazel-bin/src/bazel` as the Bazel for a workspace using `rules_r`, it fails here because `native.bazel_version` is `""`.

There might be a way to build a custom Bazel with a correct `native.bazel_version` but I couldn't find it.