### PR TITLE
Support windows in detect_os

### DIFF
--- a/internal/os.bzl
+++ b/internal/os.bzl
@@ -15,12 +15,14 @@
 def detect_os(rctx):
     """Detects the host operating system.
 
-    Returns one of "darwin" or "linux", or raises an error.
+    Returns one of "darwin", "linux" or "windows", or raises an error.
     """
     os_name = rctx.os.name.lower()
     if os_name.startswith("mac os"):
         return "darwin"
     elif os_name == "linux":
         return "linux"
+    elif os_name.startswith("windows"):
+        return "windows"
     else:
         fail("unsupported %s" % os_name)


### PR DESCRIPTION
The `fail()` in `detect_os` causes our builds to fail on Windows during `WORKSPACE` evaluation in the call to `r_register_toolchains()`, even if no R targets were requested to be built.

This allows `WORKSPACE` evaluation to succeed on Windows.